### PR TITLE
Fix github workflows ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - run: rustup component add rustfmt
+          components: rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt


### PR DESCRIPTION
Use actions-rs/toolchain@v1 to install components instead of installing
them manually. This is more robust (necessary on nightly).