### PR TITLE
Update example in readme to match recent API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use std::time::Duration;
 use ssdp_client::SearchTarget;
 
 let search_target = SearchTarget::RootDevice;
-let mut responses = ssdp_client::search(&search_target, Duration::from_secs(3), 2).await?;
+let mut responses = ssdp_client::search(&search_target, Duration::from_secs(3), 2, None).await?;
 
 while let Some(response) = responses.next().await {
     println!("{:?}", response?);


### PR DESCRIPTION
The `search` function was updated to accept a ttl argument which means
the example in the readme no longer compiled.
